### PR TITLE
luci-app-pbr-1.2.2: do not show ipv6 gateway if ipv6 is disabled

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ PKG_NAME:=luci-app-pbr
 PKG_LICENSE:=AGPL-3.0-or-later
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>
 PKG_VERSION:=1.2.2
-PKG_RELEASE:=18
+PKG_RELEASE:=20
 
 LUCI_TITLE:=Policy Based Routing Service Web UI
 LUCI_URL:=https://github.com/mossdef-org/luci-app-pbr/

--- a/htdocs/luci-static/resources/pbr/status.js
+++ b/htdocs/luci-static/resources/pbr/status.js
@@ -11,7 +11,7 @@ var pkg = {
 		return "pbr";
 	},
 	get LuciCompat() {
-		return 26;
+		return 27;
 	},
 	get ReadmeCompat() {
 		return "1.2.2";
@@ -44,7 +44,7 @@ var pkg = {
 				: template.format(info || " ")) + "<br />"
 		);
 	},
-	buildGatewayText: function (gw) {
+	buildGatewayText: function (gw, ipv6Enabled) {
 		const gateways = Array.isArray(gw) ? gw : Object.values(gw);
 		const lines = gateways.map((g) => {
 			const iface = g.name;
@@ -57,9 +57,9 @@ var pkg = {
 			const parts = [iface];
 			if (dev_ipv4 && dev_ipv4 !== iface) parts.push(dev_ipv4);
 			if (gw_ipv4) parts.push(gw_ipv4);
-			if (gw_ipv6) {
-				if (dev_ipv6 && dev_ipv6 !== iface) parts.push(dev_ipv6);
-				parts.push(gw_ipv6);
+			if (ipv6Enabled) {
+				if (gw_ipv6 && dev_ipv6 && dev_ipv6 !== iface) parts.push(dev_ipv6);
+				parts.push(gw_ipv6 || "::0");
 			}
 			let line = parts.join("/");
 			if (default_gw) line += " ✓";
@@ -293,7 +293,7 @@ var status = baseclass.extend({
 					{ class: "cbi-value-description" },
 					description,
 				);
-				text = pkg.buildGatewayText(reply.ubus.gateways);
+				text = pkg.buildGatewayText(reply.ubus.gateways, reply.status.ipv6_enabled);
 				var gatewaysText = E("div", {}, text);
 				var gatewaysField = E("div", { class: "cbi-value-field" }, [
 					gatewaysText,

--- a/htdocs/luci-static/resources/pbr/status.js
+++ b/htdocs/luci-static/resources/pbr/status.js
@@ -57,9 +57,9 @@ var pkg = {
 			const parts = [iface];
 			if (dev_ipv4 && dev_ipv4 !== iface) parts.push(dev_ipv4);
 			if (gw_ipv4) parts.push(gw_ipv4);
-			if (ipv6Enabled) {
-				if (gw_ipv6 && dev_ipv6 && dev_ipv6 !== iface) parts.push(dev_ipv6);
-				parts.push(gw_ipv6 || "::0");
+			if (ipv6Enabled && gw_ipv6) {
+				if (dev_ipv6 && dev_ipv6 !== iface) parts.push(dev_ipv6);
+				parts.push(gw_ipv6);
 			}
 			let line = parts.join("/");
 			if (default_gw) line += " ✓";

--- a/root/usr/libexec/rpcd/luci.pbr
+++ b/root/usr/libexec/rpcd/luci.pbr
@@ -10,7 +10,7 @@
 # ubus -S call luci.pbr getPlatformSupport '{"name": "pbr" }'
 # ubus -S call luci.pbr getInterfaces '{"name": "pbr" }'
 
-readonly rpcdCompat='26'
+readonly rpcdCompat='27'
 readonly pbrFunctionsFile="${IPKG_INSTROOT}/etc/init.d/pbr"
 if [ -s "$pbrFunctionsFile" ]; then
 # shellcheck source=../../../../../pbr/files/etc/init.d/pbr
@@ -108,6 +108,11 @@ get_init_status() {
 		json_add_boolean 'running_nft_file' '1'
 	else
 		json_add_boolean 'running_nft_file' '0'
+	fi
+	if [ "$(uci -q get "${packageName}.config.ipv6_enabled")" = '1' ]; then
+		json_add_boolean 'ipv6_enabled' '1'
+	else
+		json_add_boolean 'ipv6_enabled' '0'
 	fi
 	json_add_string 'version' "$PKG_VERSION"
 	json_add_int		'packageCompat'	"${packageCompat:-0}"


### PR DESCRIPTION
These patches will stop the display of IPv6 gateways if IPv6 is disabled in PBR.

Bumped release version to 20 and compat version to 27 to bring in line with the pbr-app