### PR TITLE
luci-app-pbr-1.2.3: bump compat to 34, add gateway warning strings

### DIFF
--- a/htdocs/luci-static/resources/pbr/status.js
+++ b/htdocs/luci-static/resources/pbr/status.js
@@ -11,7 +11,7 @@ var pkg = {
 		return "pbr";
 	},
 	get LuciCompat() {
-		return 33;
+		return 34;
 	},
 	get ReadmeCompat() {
 		return "1.2.3";
@@ -356,6 +356,12 @@ var status = baseclass.extend({
 						'<a href="' + pkg.URL + '#routing-tables-modes" target="_blank">',
 						"</a>",
 					),
+					warningInterfaceRoutingUnknownGateway4: _(
+						"Unknown IPv4 gateway for '%s'",
+					),
+					warningInterfaceRoutingUnknownGateway6: _(
+						"Unknown IPv6 gateway for '%s'",
+					),
 				};
 				var warningsTitle = E(
 					"label",
@@ -500,9 +506,6 @@ var status = baseclass.extend({
 					errorRequiredBinaryMissing: _("Required binary '%s' is missing"),
 					errorInterfaceRoutingUnknownDevType: _(
 						"Unknown IPv6 Link type for device '%s'",
-					),
-					errorInterfaceRoutingUnknownGateway: _(
-						"Unknown Gateway for device '%s'",
 					),
 					errorMktempFileCreate: _(
 						"Failed to create temporary file with mktemp mask: '%s'",

--- a/root/usr/share/rpcd/ucode/luci.pbr
+++ b/root/usr/share/rpcd/ucode/luci.pbr
@@ -17,7 +17,7 @@ import { access } from 'fs';
 import { cursor } from 'uci';
 
 const packageName = 'pbr'; // ucode-lsp disable
-const rpcdCompat = 33; // ucode-lsp disable
+const rpcdCompat = 34; // ucode-lsp disable
 
 // ── rpcd Method Handlers ────────────────────────────────────────────
 


### PR DESCRIPTION
Companion change to the pbr-side commit that downgrades unknown gateway detection from an error to a warning
(warningInterfaceRoutingUnknownGateway4 /
warningInterfaceRoutingUnknownGateway6, replacing
errorInterfaceRoutingUnknownGateway). As with pbr, this same error was already turned into a warning once before in 1.2.2, so this change is largely reapplying/completing that on the LuCI side to match the current pbr package.

- status.js: bump LuciCompat to 34; add warningInterfaceRoutingUnknownGateway4/6 message strings to warningTable; remove errorInterfaceRoutingUnknownGateway from errorTable.
- luci.pbr: bump rpcdCompat to 34.

Keeps LuciCompat, packageCompat, and rpcdCompat in sync at 34 so no spurious warningInternalVersionMismatch is shown once both PRs are installed together.