### PR TITLE
luci-app-pbr: add uplink_interface/uplink_interface6 advanced options

### DIFF
--- a/htdocs/luci-static/resources/view/pbr/overview.js
+++ b/htdocs/luci-static/resources/view/pbr/overview.js
@@ -184,6 +184,45 @@ return view.extend({
 		o = s.taboption(
 			"tab_advanced",
 			form.Value,
+			"uplink_interface",
+			_("Default Uplink Interface (IPv4)"),
+			_("Force the default IPv4 uplink interface used by the service. " +
+				"Select from the list of known interfaces or enter a custom interface name.")
+		);
+		if (Array.isArray(reply.interfaces)) {
+			reply.interfaces.forEach((element) => {
+				if (element.toLowerCase() !== "ignore") {
+					o.value(element, reply.interface_labels[element] || element);
+				}
+			});
+		}
+		o.datatype = "network";
+		o.default = "wan";
+		o.rmempty = true;
+
+		o = s.taboption(
+			"tab_advanced",
+			form.Value,
+			"uplink_interface6",
+			_("Default Uplink Interface (IPv6)"),
+			_("Force the default IPv6 uplink interface used by the service. " +
+				"Select from the list of known interfaces or enter a custom interface name.")
+		);
+		if (Array.isArray(reply.interfaces)) {
+			reply.interfaces.forEach((element) => {
+				if (element.toLowerCase() !== "ignore") {
+					o.value(element, reply.interface_labels[element] || element);
+				}
+			});
+		}
+		o.datatype = "network";
+		o.default = "wan6";
+		o.rmempty = true;
+		o.depends("ipv6_enabled", "1");
+
+		o = s.taboption(
+			"tab_advanced",
+			form.Value,
 			"uplink_mark",
 			_("Uplink Interface Table FW Mark"),
 			_(


### PR DESCRIPTION
Expose uplink_interface and uplink_interface6 as per-service config
overrides on the Advanced tab, letting the user force the default
IPv4/IPv6 uplink interface used by the service. These map directly
to the UCI config_schema entries in config.uc; pbr.uc derives
cfg.uplink_interface4 from cfg.uplink_interface internally at load
time and already uses it throughout split-uplink table selection
and status reporting.

- form.Value combobox: suggests known interfaces from reply.interfaces
  (pbr's supported/detected list) but also accepts a custom interface
  name not currently reported by pbr
- datatype "network" for validation
- defaults: "wan" for uplink_interface, "wan6" for uplink_interface6
- uplink_interface6 only shown when ipv6_enabled is set

Signed-off-by: Erik Conijn <egc112@msn.com>