### PR TITLE
luci-app-pbr-1.2.3: force-write uplink_interface(6) defaults

### DIFF
--- a/htdocs/luci-static/resources/view/pbr/overview.js
+++ b/htdocs/luci-static/resources/view/pbr/overview.js
@@ -199,6 +199,7 @@ return view.extend({
 		o.datatype = "network";
 		o.default = "wan";
 		o.rmempty = true;
+		o.forcewrite = true;
 
 		o = s.taboption(
 			"tab_advanced",
@@ -218,6 +219,7 @@ return view.extend({
 		o.datatype = "network";
 		o.default = "wan6";
 		o.rmempty = true;
+		o.forcewrite = true;
 		o.depends("ipv6_enabled", "1");
 
 		o = s.taboption(


### PR DESCRIPTION

Add forcewrite to uplink_interface and uplink_interface6 so the default value ("wan"/"wan6") is always persisted to UCI on save, instead of being silently skipped because the form value already equals the default and LuCI treats that as "no change."

rmempty stays enabled, so an explicitly cleared field still removes the option rather than writing an empty string.