### PR TITLE
luci-app-pbr-1.2.3: validate uplink_ip_rules_priority range in UI

### DIFF
--- a/htdocs/luci-static/resources/view/pbr/overview.js
+++ b/htdocs/luci-static/resources/view/pbr/overview.js
@@ -268,7 +268,7 @@ return view.extend({
 		);
 		o.rmempty = true;
 		o.placeholder = "30000";
-		o.datatype = "uinteger";
+		o.datatype = "range(99,32765)";
 		o.default = "30000";
 
 		s = m.section(


### PR DESCRIPTION
Companion to the pbr-side fix for uplink_ip_rules_priority values that could delete the kernel's priority 0 ip rule. The form field validated this option as a bare uinteger, so any value was accepted client-side; the actual enforcement lived only in pbr's runtime clamp.

Change the datatype to range(99,32765), matching the bounds now declared in pbr's init.d/pbr and enforced in config.uc, so an out-of-range value is rejected in the UI rather than silently corrected after the fact.