### PR TITLE
luci-app-pbr-1.2.3: refresh stale service status after Save & Apply

### DIFF
--- a/htdocs/luci-static/resources/view/pbr/overview.js
+++ b/htdocs/luci-static/resources/view/pbr/overview.js
@@ -5,6 +5,7 @@
 "require form";
 "require rpc";
 "require view";
+"require dom";
 "require pbr.status as pbr";
 /* global pbr */
 
@@ -492,6 +493,71 @@ return view.extend({
 		o.editable = true;
 		o.rmempty = false;
 
-		return Promise.all([status.render(), m.render()]);
+		return Promise.all([status.render(), m.render()]).then(function (nodes) {
+			var statusNode = nodes[0];
+
+			// Saving settings fires pbr's procd config.change trigger, which
+			// reloads the service asynchronously. LuCI reloads the page once the
+			// apply completes, so getInitStatus() often lands mid-reload and
+			// reports the service as stopped -- and nothing ever re-checked it,
+			// leaving a stale "Stopped" until the user refreshed by hand.
+			//
+			// Re-check only while the status looks like that transient state
+			// (enabled but not running), and stop as soon as it settles. A
+			// normally-running service therefore costs no extra RPC calls:
+			// getInitStatus() is expensive on the router, since every call
+			// re-runs full platform detection and dumps the nft table.
+			//
+			// This deliberately uses setTimeout rather than LuCI's poll module
+			// (same approach as pollServiceStatus() in pbr/status.js): a
+			// registered poll drives LuCI's global auto-refresh indicator, which
+			// would sit at "Paused" once we unregistered, as if the page had
+			// stalled.
+			if (statusData.enabled && !statusData.running) {
+				var attempts = 0;
+				var maxAttempts = 22; // give up after ~90s
+
+				// Check quickly at first, since a reload normally completes
+				// within a few seconds, then ease off so that a slow restart
+				// doesn't hammer an RPC this expensive -- and doesn't compete
+				// for CPU with the very reload we're waiting on.
+				var delayFor = function (done) {
+					if (done < 4) return 1500;
+					if (done < 8) return 3000;
+					return 5000;
+				};
+
+				// Re-render only once the state settles, so the service control
+				// buttons inside the status box aren't torn out from under the
+				// user on every tick.
+				var refreshStatus = function () {
+					return status.render().then(function (freshNode) {
+						dom.content(
+							statusNode,
+							Array.prototype.slice.call(freshNode.childNodes)
+						);
+					});
+				};
+
+				var checkStatus = function () {
+					attempts++;
+					L.resolveDefault(pbr.getInitStatus(pkg.Name), {})
+						.then(function (res) {
+							var reply = (res && res[pkg.Name]) || {};
+							if (reply.running || !reply.enabled || attempts >= maxAttempts)
+								return refreshStatus();
+							setTimeout(checkStatus, delayFor(attempts));
+						})
+						.catch(function () {
+							if (attempts < maxAttempts)
+								setTimeout(checkStatus, delayFor(attempts));
+						});
+				};
+
+				setTimeout(checkStatus, delayFor(0));
+			}
+
+			return nodes;
+		});
 	},
 });


### PR DESCRIPTION
Saving settings fires pbr's procd config.change trigger, which reloads the service asynchronously. LuCI reloads the page as soon as the apply completes, so getInitStatus() lands mid-reload and reports the service as stopped -- and nothing ever re-checked it, leaving a stale "Stopped" in the status box until the user refreshed the page by hand. The service control buttons already handled this via pollServiceStatus() in pbr/status.js; the plain settings-save path went through LuCI's generic form flow and had no equivalent.

Re-check the status from render(), but only while it looks like that transient state (enabled but not running), stopping as soon as it settles and giving up after ~90s. Intervals ramp 1.5s -> 3s -> 5s, so the common case flips within a couple of seconds without competing for CPU with the reload being waited on.

Gating on enabled && !running matters for cost: getInitStatus() is expensive on the router, since the rpcd handler builds a fresh pbr instance per request and so re-runs full platform detection plus an `nft list table` dump on every call. A normally-running service therefore costs no extra RPC calls at all.

Two deliberate choices worth recording:

 - setTimeout rather than LuCI's poll module, matching pollServiceStatus() in pbr/status.js. A registered poll drives LuCI's global auto-refresh indicator, which then sits at "Paused" once unregistered, reading as though the page had stalled.
 - The status box is re-rendered only once the state settles, not on every tick, so the service control buttons inside it aren't torn out from under the user while they are looking at a stopped service.

Known limitation: this covers stale "Stopped" only. If the page loads while the service is running and it later fails to come back, the box stays stale until a manual refresh -- the trade for zero polling in the healthy case. A service the user stopped deliberately also re-checks for ~90s before giving up, which is bounded and self-terminating.