### PR TITLE
luci-app-pbr-1.2.3: preserve resolver_set and uplink_interface(6) settings on save

### DIFF
--- a/htdocs/luci-static/resources/view/pbr/overview.js
+++ b/htdocs/luci-static/resources/view/pbr/overview.js
@@ -113,6 +113,15 @@ return view.extend({
 		if (reply.platform.dnsmasq_nftset_support) {
 			o.value("dnsmasq.nftset", _("Dnsmasq nft set"));
 			o.default = "dnsmasq.nftset";
+		} else if (
+			L.uci.get(pkg.Name, "config", "resolver_set") === "dnsmasq.nftset"
+		) {
+			// Support detection can fail transiently, for instance when dnsmasq
+			// is not installed or not yet running. Without the stored value in
+			// the choice list the select falls back to its first entry and
+			// saving would silently rewrite resolver_set to "none". The
+			// description above already states that support is missing.
+			o.value("dnsmasq.nftset", _("Dnsmasq nft set"));
 		}
 		// luci-base 974b5864e05e removes options whose value equals their
 		// default. pbr provisions resolver_set in /etc/config/pbr and in

--- a/htdocs/luci-static/resources/view/pbr/overview.js
+++ b/htdocs/luci-static/resources/view/pbr/overview.js
@@ -109,10 +109,16 @@ return view.extend({
 			text
 		);
 		o.value("none", _("Disabled"));
+		o.default = "none";
 		if (reply.platform.dnsmasq_nftset_support) {
 			o.value("dnsmasq.nftset", _("Dnsmasq nft set"));
 			o.default = "dnsmasq.nftset";
 		}
+		// luci-base 974b5864e05e removes options whose value equals their
+		// default. pbr provisions resolver_set in /etc/config/pbr and in
+		// uci-defaults, so without this the stored dnsmasq.nftset would be
+		// deleted on the first Save and nft set handling silently disabled.
+		o.rmempty = false;
 
 		o = s.taboption(
 			"tab_basic",
@@ -199,8 +205,10 @@ return view.extend({
 		}
 		o.datatype = "network";
 		o.default = "wan";
-		o.rmempty = true;
-		o.forcewrite = true;
+		// Keeps the default visible in /etc/config/pbr. luci-base 974b5864e05e
+		// removes values equal to the default and made forcewrite unreachable
+		// in exactly that case, so rmempty is what forces the write now.
+		o.rmempty = false;
 
 		o = s.taboption(
 			"tab_advanced",
@@ -219,8 +227,8 @@ return view.extend({
 		}
 		o.datatype = "network";
 		o.default = "wan6";
-		o.rmempty = true;
-		o.forcewrite = true;
+		// See uplink_interface above.
+		o.rmempty = false;
 		o.depends("ipv6_enabled", "1");
 
 		o = s.taboption(


### PR DESCRIPTION
Two independent fixes to `resolver_set` and `uplink_interface(6)` handling in the overview page. Each commit stands on its own; full reasoning is in the commit messages.

### 1. Adapt to the luci-base default-vs-write change

luci-base [974b5864e05e](https://github.com/openwrt/luci/commit/974b5864e05ef30f38149389f15583c08bdd4eda) ("luci-base: fix uci write bug when input value equals default") changed `CBIAbstractValue.parse()` so an option whose form value equals its declared `default` is removed from UCI instead of written, whenever `optional` or `rmempty` is set. Since `rmempty` defaults to true, this applies to nearly every option that does not explicitly opt out. It also makes `o.forcewrite = true` dead code in precisely the case it is usually added for: `forcewrite` lives in the `else if` branch that the new condition now short-circuits.

**`resolver_set`** is the real bug, and it is worse than a default failing to be written. pbr ships `option resolver_set 'dnsmasq.nftset'` in `/etc/config/pbr` and `uci-defaults/90-pbr` force-sets it on every install and upgrade, so the option is present on essentially every device. After 974b5864 the first Save of the overview page *deletes* that provisioned value, and because 90-pbr only re-runs on package upgrade, nft set handling stays off until then — the UI keeps showing nft set support enabled while pbr runs with it off and domain policies fall back to one-time resolveip lookups. Fixed with `rmempty = false`, plus an explicit `o.default = "none"` base that documents the fallback on devices without nft set support.

**`uplink_interface` / `uplink_interface6`** replace the now-dead `forcewrite` with `rmempty = false`. pbr falls back to `wan`/`wan6` when these are absent, so this is visibility only, but I want both always present in the config. This supersedes #31 — those `forcewrite` lines never actually worked, having been added after 974b5864 had already landed.

Safe on older branches without 974b5864: the upstream change is a single added clause, so on old `form.js` these options behave exactly as before. `resolver_set` is a `ListValue` with no blank choice, so `rmempty = false` is never reached, and the dropped `forcewrite` only ever forced a rewrite of an already-identical value. No config churn on up- or downgrade.

The one visible behaviour change on any branch: the `uplink_interface` fields can no longer be cleared to blank, which is intended now that they always carry a value.

### 2. Keep `resolver_set` when nft set support is undetected

This bug predates 974b5864 and is independent of it, but it defeats the same protection — one is a value removed on save, the other a value downgraded on save.

The `dnsmasq.nftset` choice is only offered when `platform.dnsmasq_nftset_support` is true, and `platform.uc` leaves that false unless dnsmasq is installed and its compile-time options can be probed. When detection fails transiently — dnsmasq missing, just removed, or not yet running as the page loads — the stored value is not among the choices. `UISelect.render()` marks an `<option>` selected only for values present in the choice list, so nothing is selected, the browser falls back to the first entry, and `getValue()` reports `none`. Saving then writes `resolver_set 'none'` and silently disables nft set handling, with nothing pointing back at the overview page as the cause.

Fixed by re-adding `dnsmasq.nftset` as a selectable choice when it is the stored value, even if support is not currently detected. The value then round-trips untouched. It reuses the existing `Dnsmasq nft set` string, so no new msgid, and needs no annotation because the field description already reports that support is missing in exactly that branch.

### Notes

No `PKG_RELEASE` bump here — handled separately.

Thanks to @pesa1234 for bringing the `resolver_set` regression to our attention; openwrt/luci#8927 is the equivalent fix for 1.2.2, which carries three resolver branches instead of one.

### Testing

On a test device with luci-app-pbr installed I set uci set pbr.config.resolver_set='dnsmasq.nftset' and confirmed that saving the Overview page preserves that value both when dnsmasq is running and when dnsmasq is stopped (the UI contains and round-trips the stored choice). I also verified that uplink_interface and uplink_interface6 are written to /etc/config/pbr and remain present after saving (including when equal to their defaults), preventing the deletion/regression introduced by luci-base 974b5864e05e.

