### PR TITLE
luci-app-pbr-1.2.3: bump PKG_RELEASE from 81 to 83

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ PKG_NAME:=luci-app-pbr
 PKG_LICENSE:=AGPL-3.0-or-later
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>, Erik Conijn <egc112@msn.com>
 PKG_VERSION:=1.2.3
-PKG_RELEASE:=81
+PKG_RELEASE:=83
 
 LUCI_TITLE:=Policy Based Routing Service Web UI
 LUCI_URL:=https://docs.mossdef.org/pbr/


### PR DESCRIPTION
Bumps `PKG_RELEASE` from 81 to 83 for the 1.2.3 dev branch, which uses uneven release numbers.

Paired with mossdef-org/pbr#148, so both packages stay in lockstep.

Makefile only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)