### PR TITLE
luci-app-pbr-1.2.3: add errorInterfacePriorityExhausted, bump compat to 35

### DIFF
--- a/htdocs/luci-static/resources/pbr/status.js
+++ b/htdocs/luci-static/resources/pbr/status.js
@@ -11,7 +11,7 @@ var pkg = {
 		return "pbr";
 	},
 	get LuciCompat() {
-		return 34;
+		return 35;
 	},
 	get ReadmeCompat() {
 		return "1.2.3";
@@ -478,6 +478,9 @@ var status = baseclass.extend({
 					),
 					errorInterfaceMarkOverflow: _(
 						"Interface mark for '%s' exceeds the fwmask value",
+					),
+					errorInterfacePriorityExhausted: _(
+						"No IP rule priority left to allocate for '%s'",
 					),
 					errorFailedToResolve: _("Failed to resolve '%s'"),
 					errorInvalidOVPNConfig: _(

--- a/root/usr/share/rpcd/ucode/luci.pbr
+++ b/root/usr/share/rpcd/ucode/luci.pbr
@@ -17,7 +17,7 @@ import { access } from 'fs';
 import { cursor } from 'uci';
 
 const packageName = 'pbr'; // ucode-lsp disable
-const rpcdCompat = 34; // ucode-lsp disable
+const rpcdCompat = 35; // ucode-lsp disable
 
 // ── rpcd Method Handlers ────────────────────────────────────────────
 


### PR DESCRIPTION
## Problem

pbr gains `errorInterfacePriorityExhausted` (mossdef-org/pbr#149), emitted when the IP rule priority counter is exhausted by the interface count. Without a matching `errorTable` entry the WebUI renders `Unknown error` instead of the actual diagnostic.

## Changes

- **`status.js`** — add the entry alongside its sibling `errorInterfaceMarkOverflow`.
- **`status.js` / `luci.pbr`** — bump `LuciCompat` and `rpcdCompat` to 35 in lockstep with pbr's `pkg.compat` / `initCompat`, so users running the new package against an older WebUI are told to update rather than silently seeing `Unknown error`.

Same rationale and shape as a556433 ("add errorInterfaceRoutingUnknownGateway, bump compat to 32").

The `.pot` is left untouched, since it is regenerated automatically.

## Pairs with

mossdef-org/pbr#149. Both must land together, or `isVersionMismatch` fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)