### PR TITLE
luci-app-pbr-1.2.2: preserve resolver_set selection on save

### DIFF
--- a/htdocs/luci-static/resources/view/pbr/overview.js
+++ b/htdocs/luci-static/resources/view/pbr/overview.js
@@ -113,6 +113,10 @@ return view.extend({
 			text
 		);
 		o.value("none", _("Disabled"));
+		// Documented fallback for devices where no resolver set support is
+		// detected; combined with rmempty = false below, the value stored in
+		// /etc/config/pbr is preserved either way.
+		o.default = "none";
 		if (reply.platform.adguardhome_ipset_support) {
 			o.value("adguardhome.ipset", _("AdGuardHome ipset"));
 			o.default = "adguardhome.ipset";
@@ -125,6 +129,16 @@ return view.extend({
 			o.value("dnsmasq.nftset", _("Dnsmasq nft set"));
 			o.default = "dnsmasq.nftset";
 		}
+		// luci-base commit 974b5864e05ef30f38149389f15583c08bdd4eda
+		// ("luci-base: form: do not write values equal to the default")
+		// removes an option whose value equals its default whenever rmempty or
+		// optional is set:
+		// https://github.com/openwrt/luci/commit/974b5864e05ef30f38149389f15583c08bdd4eda
+		// pbr ships resolver_set in /etc/config/pbr, so without rmempty = false
+		// the stored value would be deleted on the first Save and resolver set
+		// handling silently disabled. forcewrite is not an alternative here:
+		// that branch became unreachable in exactly this case.
+		o.rmempty = false;
 
 		o = s.taboption(
 			"tab_basic",


### PR DESCRIPTION
Backport of the resolver_set part of the 1.2.3 fix (#35) to the 1.2.2 branch.

REQUIRES luci-base commit 974b5864e05ef30f38149389f15583c08bdd4eda ("luci-base: form: do not write values equal to the default"), which changed CBIAbstractValue.parse() in
modules/luci-base/htdocs/luci-static/resources/form.js to:

    if (fval == null || fval == '' ||
        (fval == this.default && (this.optional || this.rmempty))) {
        ... remove() ...
    }
    else if (this.forcewrite || !isEqual(cval, fval)) {
        ... write() ...
    }

An option whose form value equals its declared o.default is now REMOVED from UCI rather than written, whenever optional or rmempty is true. rmempty defaults to true, so this silently applies to nearly every option that does not explicitly opt out.

resolver_set is affected: pbr's backend treats an absent resolver_set as disabled (files/etc/init.d/pbr unsets it when empty or 'none'), while LuCI declares a default of adguardhome.ipset / dnsmasq.ipset / dnsmasq.nftset depending on detected support. pbr ships resolver_set 'dnsmasq.nftset' in files/etc/config/pbr, so after 974b5864 the first Save of the overview page DELETES that provisioned value and resolver set handling is silently disabled: the UI keeps showing resolver set support enabled while pbr runs with it off and domain policies fall back to one-time resolveip lookups.

Unlike 1.2.3, the 1.2.2 files/etc/uci-defaults/90-pbr does not re-set resolver_set (it only renames the old resolver_ipset option), so nothing restores the value on a later package upgrade -- once deleted it stays deleted.

o.rmempty = false is the fix; cfgvalue() returns null for an absent option, so it forces the write. An explicit o.default = 'none' base is set as well: it is inert while rmempty and optional are both false, but it documents the fallback on devices without any resolver set support.

Not backported from the 1.2.3 change: the uplink_interface and uplink_interface6 adjustments, because those options do not exist in the 1.2.2 overview, and the forcewrite removal, because 1.2.2 does not use forcewrite anywhere.

Safe on older luci-base without 974b5864: resolver_set is a ListValue with no blank choice, so rmempty = false is never reached. No config churn on up- or downgrade.

Thanks to @pesa1234 for spotting this and for the equivalent fix in the openwrt/luci tree, PR #8927 ("luci-app-pbr: preserve resolver_set selection"):
https://github.com/openwrt/luci/pull/8927#discussion_r3744952779