### PR TITLE
luci-app-pbr-1.2.3: Tor policy warning strings, drop dead iptables code

### DIFF
--- a/htdocs/luci-static/resources/pbr/status.js
+++ b/htdocs/luci-static/resources/pbr/status.js
@@ -10,6 +10,12 @@ var pkg = {
 	get Name() {
 		return "pbr";
 	},
+	// Must equal pbr's pkg.compat and rpcdCompat in luci.pbr. Any change to
+	// pbr's error/warning catalog bumps all five in lockstep: pbr pkg.uc,
+	// pbr files/etc/init.d/pbr, pbr tests/04_policies/01_start_dynamic_routing,
+	// this getter, and rpcdCompat. A mismatch trips isVersionMismatch() below
+	// and tells the user their WebUI is outdated, so the two packages have to
+	// be released together.
 	get LuciCompat() {
 		return 36;
 	},

--- a/htdocs/luci-static/resources/pbr/status.js
+++ b/htdocs/luci-static/resources/pbr/status.js
@@ -11,7 +11,7 @@ var pkg = {
 		return "pbr";
 	},
 	get LuciCompat() {
-		return 35;
+		return 36;
 	},
 	get ReadmeCompat() {
 		return "1.2.3";
@@ -180,7 +180,6 @@ var status = baseclass.extend({
 			reply = {
 				enabled: reply.enabled || false,
 				running: reply.running || false,
-				running_iptables: reply.running_iptables || false,
 				running_nft: reply.running_nft || false,
 				running_nft_file: reply.running_nft_file || false,
 				version: reply.version || null,
@@ -227,9 +226,7 @@ var status = baseclass.extend({
 				text = _("Version %s").format(reply.version) + " - ";
 				if (reply.running) {
 					text += _("Running");
-					if (reply.running_iptables) {
-						text += " (" + _("iptables mode") + ").";
-					} else if (reply.running_nft_file) {
+					if (reply.running_nft_file) {
 						text += " (" + _("fw4 nft file mode") + ").";
 					} else if (reply.running_nft) {
 						text += " (" + _("nft mode") + ").";
@@ -302,14 +299,14 @@ var status = baseclass.extend({
 						"Installed AdGuardHome (%s) doesn't support 'ipset_file' option.",
 					),
 					warningPolicyProcessCMD: _("%s"),
-					warningTorUnsetParams: _(
-						"Please unset 'src_addr', 'src_port' and 'dest_port' for policy '%s'",
+					warningTorUnsetSrcPort: _(
+						"Please unset 'src_port' for policy '%s': it produces an invalid rule",
+					),
+					warningTorUnsetDestPort: _(
+						"Please unset 'dest_port' for policy '%s': it is ignored",
 					),
 					warningTorUnsetProto: _(
 						"Please unset 'proto' or set 'proto' to 'all' for policy '%s'",
-					),
-					warningTorUnsetChainIpt: _(
-						"Please unset 'chain' or set 'chain' to 'PREROUTING' for policy '%s'",
 					),
 					warningTorUnsetChainNft: _(
 						"Please unset 'chain' or set 'chain' to 'prerouting' for policy '%s'",
@@ -398,10 +395,6 @@ var status = baseclass.extend({
 					errorConfigValidation: _("Config (%s) validation failure").format(
 						"/etc/config/" + pkg.Name,
 					),
-					errorNoIptables: _("%s binary cannot be found").format("iptables"),
-					errorNoIpset: _(
-						"Resolver set support (%s) requires ipset, but ipset binary cannot be found",
-					).format(pkg.escapeInfo(L.uci.get(pkg.Name, "config", "resolver_set"))),
 					errorNoNft: _(
 						"Resolver set support (%s) requires nftables, but nft binary cannot be found",
 					).format(pkg.escapeInfo(L.uci.get(pkg.Name, "config", "resolver_set"))),
@@ -422,9 +415,6 @@ var status = baseclass.extend({
 					).format(
 						'<a href="' + pkg.URL + '#uplink_interface" target="_blank">',
 						"</a>!<br />",
-					),
-					errorIpsetNameTooLong: _(
-						"The ipset name '%s' is longer than allowed 31 characters",
 					),
 					errorNftsetNameTooLong: _(
 						"The nft set name '%s' is longer than allowed 255 characters",

--- a/htdocs/luci-static/resources/view/status/include/72_pbr.js
+++ b/htdocs/luci-static/resources/view/status/include/72_pbr.js
@@ -25,9 +25,7 @@ return baseclass.extend({
 				versionText = reply.version;
 				if (reply.running) {
 					statusText = _("Active");
-					if (reply.running_iptables) {
-						modeText = _("iptables mode");
-					} else if (reply.running_nft_file) {
+					if (reply.running_nft_file) {
 						modeText = _("fw4 nft file mode");
 					} else if (reply.running_nft) {
 						modeText = _("nft mode");

--- a/root/usr/share/rpcd/ucode/luci.pbr
+++ b/root/usr/share/rpcd/ucode/luci.pbr
@@ -17,6 +17,9 @@ import { access } from 'fs';
 import { cursor } from 'uci';
 
 const packageName = 'pbr'; // ucode-lsp disable
+// Must equal LuciCompat in pbr/status.js and pkg.compat in the pbr backend;
+// a mismatch trips isVersionMismatch() and warns the user to update. Bump all
+// five locations together whenever pbr's message catalog changes.
 const rpcdCompat = 36; // ucode-lsp disable
 
 // ── rpcd Method Handlers ────────────────────────────────────────────

--- a/root/usr/share/rpcd/ucode/luci.pbr
+++ b/root/usr/share/rpcd/ucode/luci.pbr
@@ -17,7 +17,7 @@ import { access } from 'fs';
 import { cursor } from 'uci';
 
 const packageName = 'pbr'; // ucode-lsp disable
-const rpcdCompat = 35; // ucode-lsp disable
+const rpcdCompat = 36; // ucode-lsp disable
 
 // ── rpcd Method Handlers ────────────────────────────────────────────
 


### PR DESCRIPTION
## What

Companion to **mossdef-org/pbr#150**, which restores the Tor policy warnings.

pbr now emits `warningTorUnsetSrcPort` and `warningTorUnsetDestPort` in place of the single `warningTorUnsetParams`, so the WebUI needs the matching entries or it renders *"Unknown warning"*.

- `status.js`: replace `warningTorUnsetParams` with `warningTorUnsetSrcPort` and `warningTorUnsetDestPort`. The old string told users to unset `src_addr`, which is in fact the correct way to match a Tor policy, so it is not carried over. The two new strings state their differing consequence: `src_port` produces an invalid rule, `dest_port` is merely ignored.
- compat 35 → 36 in `status.js` (`LuciCompat`) and `luci.pbr` (`rpcdCompat`).

## Dead iptables code removed

The iptables backend was removed in pbr 1.1.7 and `running_iptables` has been hardcoded `false` ever since; pbr#150 drops it from the status payload entirely.

- `status.js`: drop the `running_iptables` field and the *"(iptables mode)"* branch; drop `errorNoIptables`, `errorNoIpset` and `errorIpsetNameTooLong`, none of which exist in pbr's catalog; drop `warningTorUnsetChainIpt`, orphaned since the iptables variant was removed.
- `72_pbr.js`: drop the matching *"(iptables mode)"* branch.

Net effect on the WebUI is nil — every branch removed was unreachable and every string removed was for a code pbr cannot produce. The diff is a net deletion: +9 / −21.

## Translations

`po/templates/pbr.pot` is deliberately untouched — it is xgettext output, regenerated from the luci tree (its source references carry `applications/luci-app-pbr/` paths), not hand-maintained here. It currently still lists the removed `Please unset 'src_addr', 'src_port' and 'dest_port'...` string and does not yet carry the two new ones; that resolves on the next template regeneration. Translators will need the two new messages:

- `Please unset 'src_port' for policy '%s': it produces an invalid rule`
- `Please unset 'dest_port' for policy '%s': it is ignored`

## Not touched

- `warningAGHVersionTooLow`, dead in the same way but belonging to a separate AdGuardHome cleanup.
- The `resolver_ipset` → `resolver_set` migration in pbr's uci-defaults, still needed for upgrades from old configs.

## ⚠️ Merge together with pbr#150

These two are a matched pair. Merging either alone leaves a compat mismatch — users would see the *"WebUI application is outdated"* / version-mismatch warning until both are in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
