### PR TITLE
luci-app-pbr-1.2.3: bump PKG_RELEASE from 83 to 85

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ PKG_NAME:=luci-app-pbr
 PKG_LICENSE:=AGPL-3.0-or-later
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>, Erik Conijn <egc112@msn.com>
 PKG_VERSION:=1.2.3
-PKG_RELEASE:=83
+PKG_RELEASE:=85
 
 LUCI_TITLE:=Policy Based Routing Service Web UI
 LUCI_URL:=https://docs.mossdef.org/pbr/


### PR DESCRIPTION
### What's new in release 85

**Tor policies now tell you when a setting is being ignored.**
If you set a source port, destination port, protocol, or a chain other than prerouting on a Tor policy, pbr quietly threw it away — and a source port silently produced a rule the firewall rejects. These warnings existed years ago and were lost in a 2024 refactor. They're back, now one warning per option so each says what actually happens to your setting. Nothing is rejected; you're just told. A domain or `.onion` destination address is still supported and deliberately stays silent.

**Routers with very many interfaces no longer collide with the kernel's own routing rule.**
Once the IP rule priority counter ran out — roughly 98 or more enabled interfaces — pbr would add a rule at priority 0, on top of the kernel's own `from all lookup local`, then keep counting into negative numbers. It now skips that interface and reports "interface priority exhausted" in the WebUI, matching how firewall mark overflow already behaved.

**WebUI cleanup.** Leftover strings and code paths from the old iptables backend, gone since pbr 1.1.7, have been removed. Nothing changes on screen — every removed branch was already unreachable.

**Packaging.** The version-check script was renamed `test.sh` → `test-version.sh` to match the OpenWrt packages feed. No effect on the installed package.

**⚠️ Update both packages together.** The compatibility number moved 34 → 36 in this release. If only one is updated, the WebUI reports a version mismatch and tells you to update.

---

**luci-app-pbr commits since 83:** #37 `errorInterfacePriorityExhausted` · #39 Tor warning strings + iptables cleanup
**pbr commits since 83:** mossdef-org/pbr#149 priority-exhaustion guard · mossdef-org/pbr#150 Tor policy warnings · mossdef-org/pbr#152 `test-version.sh` rename

Pairs with the pbr bump to 85; both should land together.
