### PR TITLE
luci-app-pbr-1.2.3: bump PKG_RELEASE from 85 to 87

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ PKG_NAME:=luci-app-pbr
 PKG_LICENSE:=AGPL-3.0-or-later
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>, Erik Conijn <egc112@msn.com>
 PKG_VERSION:=1.2.3
-PKG_RELEASE:=85
+PKG_RELEASE:=87
 
 LUCI_TITLE:=Policy Based Routing Service Web UI
 LUCI_URL:=https://docs.mossdef.org/pbr/


### PR DESCRIPTION
Lockstep release bump with pbr, which is bumping to the same number in mossdef-org/pbr#157.

There are **no luci-app-pbr changes in this cycle** — nothing has landed here since the bump to 85 — and the compatibility number is unchanged at 36. So there is no version-mismatch warning either way, and nothing breaks if one package is updated before the other. This bump exists to keep the two release numbers aligned.

The user-facing changes all come from the pbr side; the changelog is in mossdef-org/pbr#157. In short: domain-based policies no longer break for a moment on every reload, already-resolved domains keep working across a reload and across stop/start, and a reload now clears the DNS cache so a re-enabled policy takes effect immediately instead of waiting for cached entries to expire.

Pairs with the pbr bump to 87; both should land together.
