### PR TITLE
luci-app-pbr-1.2.3: bump PKG_RELEASE from 87 to 89

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ PKG_NAME:=luci-app-pbr
 PKG_LICENSE:=AGPL-3.0-or-later
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>, Erik Conijn <egc112@msn.com>
 PKG_VERSION:=1.2.3
-PKG_RELEASE:=87
+PKG_RELEASE:=89
 
 LUCI_TITLE:=Policy Based Routing Service Web UI
 LUCI_URL:=https://docs.mossdef.org/pbr/


### PR DESCRIPTION
Lockstep release bump with `pbr`, which ships two fixes to how policies match:

- Negated entries in `src_addr`/`dest_addr` are applied as exclusions on the policy's other entries rather than getting a catch-all rule of their own (mossdef-org/pbr#159)
- Negated domain names in `dest_addr` no longer point at an `nft` set that was never created, which previously stopped the whole ruleset from installing (mossdef-org/pbr#159)
- Editing a policy's domain names now clears the addresses the old ones had resolved to (mossdef-org/pbr#158)

No `luci-app-pbr` changes in this cycle and compat is unchanged at 36, so neither package warns about a version mismatch; the bump keeps the two release numbers aligned.

Paired with mossdef-org/pbr#160.

🤖 Generated with [Claude Code](https://claude.com/claude-code)