### PR TITLE
luci-app-pbr-1.2.3: bump PKG_RELEASE from 89 to 91

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ PKG_NAME:=luci-app-pbr
 PKG_LICENSE:=AGPL-3.0-or-later
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>, Erik Conijn <egc112@msn.com>
 PKG_VERSION:=1.2.3
-PKG_RELEASE:=89
+PKG_RELEASE:=91
 
 LUCI_TITLE:=Policy Based Routing Service Web UI
 LUCI_URL:=https://docs.mossdef.org/pbr/


### PR DESCRIPTION
Lockstep release bump with `pbr`, which ships a fix for split uplinks (mossdef-org/pbr#161).

Where `uplink_interface4` and `uplink_interface6` name different interfaces, the second of the two was pointed at another interface's mark chain — so a policy, or a `<iface>_dscp` / `icmp_interface` option naming it, sent traffic out that interface. Where no interface owned that mark, the ruleset failed to load and `pbr` installed no rules at all.

No `luci-app-pbr` changes in this cycle and compat is unchanged at 36, so neither package warns about a version mismatch; the bump keeps the two release numbers aligned.

Paired with mossdef-org/pbr#162.

🤖 Generated with [Claude Code](https://claude.com/claude-code)