### PR TITLE
luci-app-pbr-1.2.2: add symmetric return routing UI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ PKG_NAME:=luci-app-pbr
 PKG_LICENSE:=AGPL-3.0-or-later
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>, Erik Conijn <egc112@msn.com>
 PKG_VERSION:=1.2.2
-PKG_RELEASE:=22
+PKG_RELEASE:=23
 
 LUCI_TITLE:=Policy Based Routing Service Web UI
 LUCI_URL:=https://github.com/mossdef-org/luci-app-pbr/

--- a/htdocs/luci-static/resources/view/pbr/overview.js
+++ b/htdocs/luci-static/resources/view/pbr/overview.js
@@ -150,6 +150,39 @@ return view.extend({
 		o.value("1", _("Enabled"));
 
 		o = s.taboption(
+			"tab_basic",
+			form.Flag,
+			"symmetric_return",
+			_("Symmetric return routing"),
+			_(
+				"Remember the interface used by a new incoming connection and route its replies through the same interface. " +
+					"This applies to forwarded connections and services running on the router."
+			)
+		);
+		o.default = "0";
+		o.rmempty = false;
+
+		o = s.taboption(
+			"tab_basic",
+			form.MultiValue,
+			"symmetric_return_interface",
+			_("Symmetric return interfaces"),
+			_(
+				"Select the external or tunnel interfaces whose incoming connections must return through the same path."
+			)
+		);
+		o.depends("symmetric_return", "1");
+		reply.interfaces.forEach((element) => {
+			if (
+				element.toLowerCase() !== "ignore" &&
+				element.toLowerCase() !== "tor"
+			) {
+				o.value(element);
+			}
+		});
+		o.rmempty = true;
+
+		o = s.taboption(
 			"tab_advanced",
 			form.DynamicList,
 			"supported_interface",


### PR DESCRIPTION
Expose the `symmetric_return` and `symmetric_return_interface` options added to pbr 1.2.2.

- `symmetric_return` as a Flag defaulting to off.
- `symmetric_return_interface` as a MultiValue over the interfaces reported by the rpcd backend, minus the `ignore` and `tor` pseudo interfaces, which cannot carry ingress connections. Shown only when symmetric_return is enabled.

Credit is extended to a contributor who wishes to remain anonymous.