### PR TITLE
luci-app-pbr-1.2.3: bump PKG_RELEASE from 93 to 95

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ PKG_NAME:=luci-app-pbr
 PKG_LICENSE:=AGPL-3.0-or-later
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>, Erik Conijn <egc112@msn.com>
 PKG_VERSION:=1.2.3
-PKG_RELEASE:=93
+PKG_RELEASE:=95
 
 LUCI_TITLE:=Policy Based Routing Service Web UI
 LUCI_URL:=https://docs.mossdef.org/pbr/


### PR DESCRIPTION
What changed since **1.2.3-r93**.

Three of these are the same failure: `pbr` would build an `nft` ruleset that `nft` refused, and because the whole file is checked in one go, refusing one line meant refusing all of it. The service then reported `ERROR: Failed to install fw4 nft file` and `FAILED TO START`, and **no** policy routed — not just the one at fault.

- **A policy name with a `"`, a line break, or over 128 bytes no longer breaks everything.** The name is copied into every `nft` comment a policy produces, and a double quote has no escape in that syntax, so one awkward name took the whole ruleset down. Names are now sanitised where they enter: `"` becomes `'`, line breaks become spaces, and anything past `nft`'s 128-byte limit is trimmed.
- **`nft_set_timeout` and `nft_set_gc_interval` work.** Previously any value at all was written in a form `nft` rejected, so the options were unusable — setting one stopped the service from starting. A value that is not a valid `nft` time value (`30s`, `6h`, `1h30m`; note there is no unit for weeks) is now ignored rather than reaching the ruleset. This matters beyond the options themselves: a timeout is the only thing that ages old addresses out of a domain policy's set, so until now that advice could not actually be followed.
- **A Tor policy no longer breaks the ruleset when Tor is not running.** The redirect ports are read from `torrc` instead of from the running daemon, so they are correct while Tor is still starting — which is the normal case at boot, since `pbr` starts before Tor does. A Tor policy on a router with no `torrc` at all is now reported as having an unknown interface rather than producing an invalid rule.

Two smaller ones:

- **Arguments are quoted individually** in the commands `pbr` runs, so interface and policy names containing spaces or shell punctuation are passed through as written.
- **The `Unknown IPv6 gateway` warning is no longer logged twice** for the same interface.

Nothing here changes configuration or behaviour for a working setup — no settings move, none are renamed, and the compatibility number is unchanged, so no `luci-app-pbr` update is required beyond keeping the two in step.

No code changes in `luci-app-pbr` for this release — this bump keeps it in lockstep with `pbr`.

`PKG_RELEASE` on the `1.2.3` branch moves in steps of two and stays odd — …87, 89, 91, 93, 95. r94 is not a skipped release; there is no even number in this series.

Paired with mossdef-org/pbr#176.
