### PR TITLE
luci-app-pbr-1.2.3: offer only usable protocols, add the proto/ICMP messages

### DIFF
--- a/htdocs/luci-static/resources/pbr/status.js
+++ b/htdocs/luci-static/resources/pbr/status.js
@@ -17,7 +17,7 @@ var pkg = {
 	// and tells the user their WebUI is outdated, so the two packages have to
 	// be released together.
 	get LuciCompat() {
-		return 36;
+		return 37;
 	},
 	get ReadmeCompat() {
 		return "1.2.3";
@@ -305,6 +305,12 @@ var status = baseclass.extend({
 						"Installed AdGuardHome (%s) doesn't support 'ipset_file' option.",
 					),
 					warningPolicyProcessCMD: _("%s"),
+					warningPolicyProtoNoPort: _(
+						"Policy %s: 'proto' is ignored without a port, so every protocol is routed; set the port range to '0-65535' to match all of it",
+					),
+					warningPolicyProtoPortless: _(
+						"Policy %s: this protocol cannot be matched by a policy and is ignored; to route ICMP use the 'Default ICMP Interface' setting instead",
+					),
 					warningTorUnsetSrcPort: _(
 						"Please unset 'src_port' for policy '%s': it produces an invalid rule",
 					),
@@ -458,6 +464,9 @@ var status = baseclass.extend({
 					),
 					errorPolicyProcessMismatchFamily: _(
 						"Mismatched IP family between in policy '%s'",
+					),
+					errorPolicyProtoPortNotSupported: _(
+						"Policy %s: this protocol cannot match a port; unset the port, otherwise nft rejects the whole ruleset",
 					),
 					errorPolicyProcessUnknownProtocol: _(
 						"Unknown protocol in policy '%s'",

--- a/htdocs/luci-static/resources/view/pbr/overview.js
+++ b/htdocs/luci-static/resources/view/pbr/overview.js
@@ -340,25 +340,53 @@ return view.extend({
 		o = s.option(form.ListValue, "proto", _("Protocol"));
 		o.value("", _("all"));
 		o.default = "";
-		var popularProtos = ["tcp", "udp", "tcp udp", "icmp"];
+		// 'proto' only ever reaches a rule as a prefix on sport/dport, so a
+		// protocol that cannot carry a port cannot work here: with a port it
+		// emits e.g. 'icmp dport { 53 }', which nft refuses -- rejecting the
+		// whole ruleset -- and without one it is dropped and the policy matches
+		// every protocol. reply.protocols is built from /etc/protocols, so most
+		// of what it lists is unusable; offer only what nft can actually match.
+		// To route ICMP use "Default ICMP Interface" on the Advanced tab.
+		var portCapable = ["tcp", "udp", "sctp", "dccp", "udplite"];
+		var usableProtos = reply.protocols.filter(function (p) {
+			return portCapable.indexOf(p) !== -1;
+		});
+		// "tcp udp" is a composite value, not a protocol: pbr splits proto on
+		// whitespace and emits one rule per token, and it is by far the most
+		// common pairing, so it stays as a single convenient choice.
+		var popularProtos = ["tcp", "udp", "tcp udp"];
+		// Every value actually offered, so the fallback below can tell whether a
+		// configured value is still in the list. Added in the same place as
+		// o.value() so the two cannot drift apart.
+		var offered = [""];
+		function offer(p, label) {
+			if (offered.indexOf(p) !== -1) return false;
+			label ? o.value(p, label) : o.value(p);
+			offered.push(p);
+			return true;
+		}
 		var hasPopular = false;
 		popularProtos.forEach(function (p) {
 			if (p === "tcp udp") {
-				if (reply.protocols.indexOf("tcp") !== -1 && reply.protocols.indexOf("udp") !== -1) {
-					o.value(p);
-					hasPopular = true;
+				if (usableProtos.indexOf("tcp") !== -1 && usableProtos.indexOf("udp") !== -1) {
+					if (offer(p)) hasPopular = true;
 				}
-			} else if (reply.protocols.indexOf(p) !== -1) {
-				o.value(p);
-				hasPopular = true;
+			} else if (usableProtos.indexOf(p) !== -1) {
+				if (offer(p)) hasPopular = true;
 			}
 		});
 		var hasOther = false;
-		reply.protocols.forEach(function (p) {
+		usableProtos.forEach(function (p) {
 			if (popularProtos.indexOf(p) === -1) {
-				o.value(p);
-				hasOther = true;
+				if (offer(p)) hasOther = true;
 			}
+		});
+		// Keep whatever an existing config already holds, even though it is no
+		// longer offered -- otherwise opening this page silently rewrites the
+		// policy to 'all' on the next save, changing what it matches.
+		L.uci.sections(pkg.Name, "policy", function (sec) {
+			var cur = sec.proto;
+			if (cur) offer(cur, cur + " " + _("(unsupported)"));
 		});
 		o.rmempty = true;
 		if (hasPopular && hasOther) {

--- a/root/usr/share/rpcd/ucode/luci.pbr
+++ b/root/usr/share/rpcd/ucode/luci.pbr
@@ -20,7 +20,7 @@ const packageName = 'pbr'; // ucode-lsp disable
 // Must equal LuciCompat in pbr/status.js and pkg.compat in the pbr backend;
 // a mismatch trips isVersionMismatch() and warns the user to update. Bump all
 // five locations together whenever pbr's message catalog changes.
-const rpcdCompat = 36; // ucode-lsp disable
+const rpcdCompat = 37; // ucode-lsp disable
 
 // ── rpcd Method Handlers ────────────────────────────────────────────
 


### PR DESCRIPTION
Paired with **mossdef-org/pbr#177**, which reports a `proto` that cannot work and fixes `icmp_interface` on IPv6.

## The dropdown offered protocols that cannot work

The **Protocol** field was built from every line of `/etc/protocols` — 46 entries on a stock 25.12. But `proto` only ever reaches an nft rule as a prefix on `sport`/`dport`, and only five protocols can carry a port. Measured against nftables 1.1.6:

| protocol | `<proto> dport` |
|---|---|
| `tcp` `udp` `sctp` `dccp` `udplite` | accepted |
| `icmp` `igmp` `gre` `esp` `ah` `ipv6-icmp` … | **REJECTED** |

So 41 of the choices offered could not work: with a port they emit e.g. `icmp dport { 53 }`, which nft refuses — rejecting the whole ruleset and stopping the service — and without one the protocol is dropped and the policy matches everything.

The dropdown now offers only the five. To route ICMP there is already **Default ICMP Interface** on the Advanced tab.

## Existing configs are preserved

A value a config already holds is still listed, labelled `(unsupported)`. Without that, opening this page and saving would silently rewrite the policy to `all` and change what it matches.

This does **not** replace the service-side warnings in pbr#177 — UCI can be edited directly, and existing configs already contain these values.

## Also

- WebUI strings for the four new codes: `warningPolicyProtoNoPort`, `warningPolicyProtoPortless`, `errorPolicyProtoPortNotSupported`, `errorPolicyUnknownChain` — without them the WebUI renders "Unknown error".
- `LuciCompat` and `rpcdCompat` 36 → 37, matching the three on the pbr side.

Paired with mossdef-org/pbr#177.
