### PR TITLE
luci-app-pbr-1.2.3: bump PKG_RELEASE from 95 to 97

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ PKG_NAME:=luci-app-pbr
 PKG_LICENSE:=AGPL-3.0-or-later
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>, Erik Conijn <egc112@msn.com>
 PKG_VERSION:=1.2.3
-PKG_RELEASE:=95
+PKG_RELEASE:=97
 
 LUCI_TITLE:=Policy Based Routing Service Web UI
 LUCI_URL:=https://docs.mossdef.org/pbr/


### PR DESCRIPTION
What changed since **1.2.3-r95**.

Three faults, all of which stopped the service from starting. `pbr` validates its whole `nft` file in one pass, so any one of them meant `FAILED TO START` and **no** policy routing at all — not just the policy at fault.

- **Setting *Default ICMP Interface* broke the service when IPv6 is enabled.** The IPv6 rule was written as `ip6 protocol icmp`, which `nft` refuses: IPv6 headers have no `protocol` field, and the IPv6 ICMP protocol is `icmpv6`. Anyone who set that option and had IPv6 on lost all policy routing. It is now emitted correctly.

- **A policy's `Protocol` setting is reported when it cannot do what it looks like it does.** `proto` qualifies a port match rather than matching on its own, so setting it *without* a port silently dropped it and the policy routed **every** protocol instead of the one you chose. Setting it to a protocol that has no ports — `icmp` and most of the list — *with* a port produced a rule `nft` refuses. The first is now a warning naming the policy; the second rejects just that policy, so the rest of the ruleset survives.

- **The `Protocol` dropdown now offers only protocols that can work** — `tcp`, `udp`, `sctp`, `dccp`, `udplite`. The list was previously built from every line of `/etc/protocols`, and 41 of the 46 entries it offered could not work. A value an existing policy already holds is still shown, marked `(unsupported)`, so opening the page does not silently change your configuration.

**To route ICMP**, use *Default ICMP Interface* on the Advanced tab rather than a policy — a policy cannot express it. If you want "all traffic of one protocol", set the protocol and give it the port range `0-65535`.

Documentation for all of this is in [the 1.2.3 README](https://docs.mossdef.org/pbr/1.2.3/#a-word-about-proto-and-ports), which also corrects the `chain` option: `input` and `postrouting` were listed for years and have never worked — the valid values are `prerouting`, `forward` and `output`.

The compatibility number moves to 37, so `pbr` and `luci-app-pbr` must be updated together.

`PKG_RELEASE` on the `1.2.3` branch moves in steps of two and stays odd — …91, 93, 95, 97. r96 is not a skipped release; there is no even number in this series.

Paired with https://github.com/mossdef-org/pbr/pull/178
