### PR TITLE
luci-app-pbr-1.2.3: refresh the status when a corrected warning should clear

### DIFF
--- a/htdocs/luci-static/resources/view/pbr/overview.js
+++ b/htdocs/luci-static/resources/view/pbr/overview.js
@@ -544,23 +544,64 @@ return view.extend({
 			// Saving settings fires pbr's procd config.change trigger, which
 			// reloads the service asynchronously. LuCI reloads the page once the
 			// apply completes, so getInitStatus() often lands mid-reload and
-			// reports the service as stopped -- and nothing ever re-checked it,
-			// leaving a stale "Stopped" until the user refreshed by hand.
+			// reports state that is already out of date -- and nothing ever
+			// re-checks it. Nothing in this app registers a poll, so whatever is
+			// on screen after that first fetch stays there until the user
+			// refreshes by hand.
 			//
-			// Re-check only while the status looks like that transient state
-			// (enabled but not running), and stop as soon as it settles. A
-			// normally-running service therefore costs no extra RPC calls:
-			// getInitStatus() is expensive on the router, since every call
-			// re-runs full platform detection and dumps the nft table.
+			// Two ways that shows up. A service caught mid-restart reads as
+			// stopped and stays "Stopped". And -- since r97 reports a policy's
+			// 'proto' and rejects an unusable chain -- a warning the user has
+			// just corrected stays on screen, because the reload never makes the
+			// service look stopped, so the old check (enabled && !running) never
+			// armed for it.
+			//
+			// So arm whenever there is something that could still change: the
+			// service is not running yet, or the status carries messages that a
+			// reload may be about to revise.
 			//
 			// This deliberately uses setTimeout rather than LuCI's poll module
 			// (same approach as pollServiceStatus() in pbr/status.js): a
 			// registered poll drives LuCI's global auto-refresh indicator, which
 			// would sit at "Paused" once we unregistered, as if the page had
 			// stalled.
-			if (statusData.enabled && !statusData.running) {
+			var hasMessages = function (reply) {
+				return (
+					((reply.errors || []).length > 0) ||
+					((reply.warnings || []).length > 0)
+				);
+			};
+
+			// Everything the status box shows that a config change can alter.
+			// Comparing it across ticks lets us stop as soon as the service has
+			// settled, instead of guessing how long a reload takes -- a large
+			// config can take the better part of a minute.
+			var stateSignature = function (reply) {
+				// Sorted, so a reload that reports the same messages in a
+				// different order counts as settled instead of flip-flopping
+				// until the attempt limit. The order pbr emits them in follows
+				// its policy processing and is not something the panel depends
+				// on.
+				var codes = function (list) {
+					return (list || [])
+						.map(function (m) {
+							return m.code + "\u0000" + m.info;
+						})
+						.sort();
+				};
+				return JSON.stringify([
+					!!reply.running,
+					!!reply.enabled,
+					codes(reply.errors),
+					codes(reply.warnings),
+				]);
+			};
+
+			if (statusData.enabled && (!statusData.running || hasMessages(statusData))) {
 				var attempts = 0;
 				var maxAttempts = 22; // give up after ~90s
+				var initialSig = stateSignature(statusData);
+				var lastSig = initialSig;
 
 				// Check quickly at first, since a reload normally completes
 				// within a few seconds, then ease off so that a slow restart
@@ -577,6 +618,7 @@ return view.extend({
 				// user on every tick.
 				var refreshStatus = function () {
 					return status.render().then(function (freshNode) {
+						if (statusNode.isConnected === false) return;
 						dom.content(
 							statusNode,
 							Array.prototype.slice.call(freshNode.childNodes)
@@ -585,12 +627,31 @@ return view.extend({
 				};
 
 				var checkStatus = function () {
+					// Stop if the user has navigated away: LuCI replaces the
+					// view but pending timers keep running, and getInitStatus()
+					// is expensive enough that polling a page nobody is looking
+					// at is worth avoiding. Written as `=== false` so a browser
+					// without isConnected simply behaves as before.
+					if (statusNode.isConnected === false) return;
+
 					attempts++;
 					L.resolveDefault(pbr.getInitStatus(pkg.Name), {})
 						.then(function (res) {
 							var reply = (res && res[pkg.Name]) || {};
-							if (reply.running || !reply.enabled || attempts >= maxAttempts)
-								return refreshStatus();
+							var sig = stateSignature(reply);
+
+							// Settled once two consecutive reads agree, or we
+							// have waited long enough.
+							if (sig === lastSig || attempts >= maxAttempts) {
+								// Only redraw if what is on screen is actually
+								// out of date. A service sitting on a permanent
+								// warning therefore costs one extra RPC per page
+								// load and no redraw at all.
+								if (sig !== initialSig) return refreshStatus();
+								return;
+							}
+
+							lastSig = sig;
 							setTimeout(checkStatus, delayFor(attempts));
 						})
 						.catch(function () {


### PR DESCRIPTION
#33 added a re-check for a status fetched mid-reload, but armed it only on `enabled && !running` — the shape of the problem it was chasing, where a service caught mid-restart reads as stopped and stays *Stopped*.

**Saving a policy does not make the service look stopped.** It reloads, stays running throughout, and the status fetched right after the apply is simply out of date. Nothing in this app registers a poll — `grep -rn "poll.add\|L.Poll" htdocs/` finds nothing — so whatever landed on screen stays there until the user refreshes by hand.

That barely mattered while the status box only reported running/stopped. It matters now: r97 reports a policy's `proto` when it cannot take effect and rejects an unusable chain, so a user corrects the policy, saves, and **the warning they just fixed sits there looking unfixed**.

## The change

Arm whenever something could still change — not running yet, **or** the status carries messages a reload may be about to revise:

```js
if (statusData.enabled && (!statusData.running || hasMessages(statusData)))
```

and stop as soon as **two consecutive reads agree**, rather than as soon as the service is running. A large config takes the better part of a minute to reload, so any fixed delay would be a guess; comparing successive reads settles exactly when the service does.

The signature covers `running`, `enabled`, and the error/warning codes with their `info` — everything in the box that a config change can alter.

## Cost

This is what #33 was careful about, since `getInitStatus()` re-runs platform detection and dumps the nft table:

| situation | cost |
|---|---|
| healthy, nothing reported | arms nothing — unchanged |
| permanent warning (e.g. a blackhole interface's unknown gateway) | **one** extra RPC per page load, **no redraw** — the first re-read matches, so it settles at once and the redraw is skipped because the state equals what is on screen |
| genuinely mid-reload | polls with the existing backoff until settled, then one redraw |

## Verified on hardware

25.12 running pbr 1.2.3-r97. A policy warning about `proto` with no port, corrected with `dest_port '0-65535'` and applied:

- its warning **cleared on its own** within a few seconds, with no manual refresh;
- a second policy left uncorrected **kept** its warning — which is what shows the panel re-read rather than merely blanking.

luci-only. No `pbr` change, no compat bump.
